### PR TITLE
Ajout de l'option pour masquer la dificulté lors d'un jet d'arme

### DIFF
--- a/module/controllers/roll.js
+++ b/module/controllers/roll.js
@@ -201,14 +201,17 @@ export class CofRoll {
     static async rollWeaponDialog(actor, label, mod, bonus, critrange, dmgFormula, dmgBonus, onEnter = "submit") {
         const rollOptionTpl = 'systems/cof/templates/dialogs/roll-weapon-dialog.hbs';
         let diff = null;
+        let haveTarget = false;
         if (game.settings.get("cof", "displayDifficulty") && game.user.targets.size > 0) {
             diff = [...game.user.targets][0].actor.data.data.attributes.def.value;
+            haveTarget = true;
         }
         const rollOptionContent = await renderTemplate(rollOptionTpl, {
             mod: mod,
             bonus: bonus,
             critrange: critrange,
             difficulty: diff,
+            haveTarget: haveTarget,
             dmgFormula: dmgFormula,
             dmgBonus: dmgBonus,
             dmgCustomFormula: ""

--- a/module/system/helpers.js
+++ b/module/system/helpers.js
@@ -149,6 +149,16 @@ export const registerHandlebarsHelpers = function () {
         return game.settings.get("cof", configKey);
     });
 
+    Handlebars.registerHelper('DisplayDifficulty', function(haveTarget) {
+        if (game.settings.get("cof", "displayDifficulty")) {
+            if (haveTarget && game.settings.get("cof", "hideDifficulty")) {
+                return false;
+            }
+            return true;
+        }
+        return false;
+    })
+
     Handlebars.registerHelper('split', function (str, separator, keep) {
         return str.split(separator)[keep];
     });

--- a/module/system/settings.js
+++ b/module/system/settings.js
@@ -50,6 +50,16 @@ export const registerSystemSettings = function() {
         onChange: lang => window.location.reload()
     });
 
+    game.settings.register("cof", "hideDifficulty", {
+        name: "Masque la difficulté de la cible",
+        hint: "Cache la valeur de la difficulté de la cible sur les jet de d'armes.",
+        scope: "world",
+        config: true,
+        default: true,
+        type: Boolean,
+        onChange: lang => window.location.reload() 
+    })
+
     game.settings.register("cof", "useComboRolls", {
         name: "Active les jets \"combo\"",
         hint: "Permet de lancer les jets d'attaque et de dommage simultanément.",

--- a/templates/chat/skill-roll-card.hbs
+++ b/templates/chat/skill-roll-card.hbs
@@ -14,7 +14,9 @@
             <h2 class="failure"><i class="fas fa-times"></i>&nbsp;{{localize "COF.roll.failure"}}...</h2>
         {{/if}}
     {{/if}}
-    <h3><strong>{{label}}</strong> {{localize "COF.ui.difficulty"}} <strong>{{difficulty}}</strong></h3>
+    {{#if (DisplayDifficulty false)}}
+        <h3><strong>{{label}}</strong> {{localize "COF.ui.difficulty"}} <strong>{{difficulty}}</strong></h3>
+    {{/if}}
 {{else}}
     {{#if isCritical}}
         <h2 class="standard critical"><i class="fas fa-check-double"></i>&nbsp;{{localize "COF.roll.critical"}}...</h2>

--- a/templates/dialogs/roll-weapon-dialog.hbs
+++ b/templates/dialogs/roll-weapon-dialog.hbs
@@ -48,7 +48,7 @@
     </div>
 </div>
 <hr/>
-{{#if (isEnabled "displayDifficulty")}}
+{{#if (DisplayDifficulty haveTarget)}}
 <!-- DIFFICULTY -->
 <div class="row flexrow" style="margin-bottom: 5px;">
     <div class="flex1 center bg-darkslate">


### PR DESCRIPTION
Ajout d'une option afin de masquer la difficulté lors d'un jet d'arme si le GM ne souhaite pas que les joueur connaisse la difficulté de la cible du joueur