### PR TITLE
Ajout de la macro rollWeaponMacro

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -342,6 +342,8 @@
   "COF.notification.MacroItemMissing" : "Your controlled Actor does not have such an item.",
   "COF.notification.MacroItemUnequiped" : "Item is unequiped",
 
+  "COF.notification.MacroWeaponMissing" : "Your controlled Actor does not have such an attack.",
+
   "COF.dialog.deletePath.title": "Delete the path ?",
   "COF.dialog.deleteProfile.title": "Delete the profile ?",
   "COF.dialog.deleteSpecie.title": "Delete the specie ?",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -342,6 +342,8 @@
 
   "COF.notification.MacroItemMissing" : "Le personnage ne possède pas cet objet",
   "COF.notification.MacroItemUnequiped" : "L'objet n'est pas équipé",
+  
+  "COF.notification.MacroWeaponMissing" : "Le personnage ne possède pas cette attaque",
 
   "COF.dialog.deletePath.title": "Supprimer la voie ?",
   "COF.dialog.deleteProfile.title": "Supprimer le profil ?",

--- a/module/system/macros.js
+++ b/module/system/macros.js
@@ -91,4 +91,26 @@ export class Macros {
         }
         else { return item.sheet.render(true); }
     };
+
+    static rollWeaponMacro = function (weaponName, bonus = 0, malus = 0, dmgBonus = 0, dmgOnly = false, customLabel, skillDescr, dmgDescr) {
+        const actor = this.getSpeakersActor();
+
+        let weapon;
+        if (actor?.data?.data?.weapons) {
+            const weapons = actor.data.data.weapons;
+            for (const id in weapons) {
+                if (Object.hasOwnProperty.call(weapons, id)) {
+                    if (weapons[id].name === weaponName) {
+                        weapon = weapons[id];
+                    }
+                }
+            }
+        }
+        if (!weapon) return ui.notifications.warn(`${game.i18n.localize("COF.notification.MacroWeaponMissing")}: "${weaponName}"`);
+
+        const label = customLabel && customLabel.length > 0 ? customLabel : weaponName;
+
+        if (dmgOnly) { CofRoll.rollDamageDialog(actor, label, weapon.dmg, 0, false, "submit", dmgDescr); }
+        else CofRoll.rollWeaponDialog(actor, label, weapon.mod, bonus, malus, weapon.critrange, weapon.dmg, dmgBonus, "submit", skillDescr, dmgDescr);
+    };
 }


### PR DESCRIPTION
Cette macro permet de lancer une attaque d'un actor via la modale de jets de dés.

Elle me sert pour pouvoir lancer une attaque d'un monstre ou du loup du rodeur facilement depuis la barre de raccourcis.