### PR TITLE
Afficher la difficulté uniquement au MJ

### DIFF
--- a/module/controllers/skill-roll.js
+++ b/module/controllers/skill-roll.js
@@ -1,8 +1,8 @@
-import {CofDamageRoll} from "./dmg-roll.js";
+import { CofDamageRoll } from "./dmg-roll.js";
 
 export class CofSkillRoll {
 
-    constructor(label, dice, mod, bonus, malus, difficulty, critrange, description){
+    constructor(label, dice, mod, bonus, malus, difficulty, critrange, description) {
         this._label = label;
         this._dice = dice;
         this._mod = mod;
@@ -12,42 +12,46 @@ export class CofSkillRoll {
         this._total = parseInt(this._mod) + this._totalBonusMalus;
         this._difficulty = difficulty;
         this._critrange = critrange;
-        this._formula = (this._total === 0) ? this._dice : ((this._totalBonusMalus === 0) ? `${this._dice} ${this._mod}`: `${this._dice} ${this._mod} + ${this._totalBonusMalus}`);
+        this._formula = (this._total === 0) ? this._dice : ((this._totalBonusMalus === 0) ? `${this._dice} ${this._mod}` : `${this._dice} ${this._mod} + ${this._totalBonusMalus}`);
         this._isCritical = false;
         this._isFumble = false;
         this._isSuccess = false;
         this._description = description;
     }
 
-    async roll(actor){
+    async roll(actor) {
         let r = new Roll(this._formula);
-        await r.roll({"async": true});
+        await r.roll({ "async": true });
         // Getting the dice kept in case of 2d12 or 2d20 rolls
         const result = r.terms[0].results.find(r => r.active).result;
         this._isCritical = ((result >= this._critrange.split("-")[0]) || result == 20);
         this._isFumble = (result == 1);
-        if(this._difficulty){
+        if (this._difficulty) {
             this._isSuccess = r.total >= this._difficulty;
         }
         this._buildRollMessage().then(msgFlavor => {
             r.toMessage({
                 user: game.user.id,
                 flavor: msgFlavor,
-                speaker: ChatMessage.getSpeaker({actor: actor})
+                speaker: ChatMessage.getSpeaker({ actor: actor })
             });
         })
     }
 
-    async weaponRoll(actor, dmgFormula, dmgDescr){
+    async weaponRoll(actor, dmgFormula, dmgDescr) {
         await this.roll(actor);
         if (this._difficulty) {
-            if(this._isSuccess && game.settings.get("cof", "useComboRolls")){
+            // Si l'option displayDifficulty est configurée sur GM, toujours lancer le dé de dégat
+            // pour ne pas dévoiler le résultat du dé de compétence
+            if (
+                (this._isSuccess || game.settings.get("cof", "displayDifficulty") === "GM")
+                && game.settings.get("cof", "useComboRolls")) {
                 let r = new CofDamageRoll(this._label, dmgFormula, this._isCritical, dmgDescr);
                 await r.roll(actor);
             }
         }
         else {
-            if(game.settings.get("cof", "useComboRolls")){
+            if (game.settings.get("cof", "useComboRolls")) {
                 let r = new CofDamageRoll(this._label, dmgFormula, this._isCritical, dmgDescr);
                 await r.roll(actor);
             }
@@ -56,16 +60,18 @@ export class CofSkillRoll {
 
     _buildRollMessage() {
         const rollMessageTpl = 'systems/cof/templates/chat/skill-roll-card.hbs';
+        const displayDifficulty = game.settings.get("cof", "displayDifficulty");
+
         const tplData = {
-            label : this._label,
-            difficulty : this._difficulty,
-            showDifficulty : !!this._difficulty,
-            isCritical : this._isCritical,
-            isFumble : this._isFumble,
-            isSuccess : this._isSuccess,
-            isFailure : !this._isSuccess,
-            hasDescription : this._description && this._description.length > 0,
-			description : this._description       
+            label: this._label,
+            difficulty: this._difficulty,
+            showDifficulty: !!this._difficulty && displayDifficulty !== "none",
+            isCritical: this._isCritical,
+            isFumble: this._isFumble,
+            isSuccess: this._isSuccess,
+            isFailure: !this._isSuccess,
+            hasDescription: this._description && this._description.length > 0,
+            description: this._description
         };
         return renderTemplate(rollMessageTpl, tplData);
     }

--- a/module/system/helpers.js
+++ b/module/system/helpers.js
@@ -1,4 +1,4 @@
-import {Traversal} from "../utils/traversal.js";
+import { Traversal } from "../utils/traversal.js";
 
 export const registerHandlebarsHelpers = function () {
 
@@ -63,17 +63,17 @@ export const registerHandlebarsHelpers = function () {
     // Handlebars.registerHelper('getCapacitiesByIds', function (ids) {
     //     if (ids) {
     //         console.log(ids);
-            // const caps = Traversal.getItemsOfType(["capacity"]);
-            // console.log(caps);
-                // .filter(c => ids.includes(c._id));
-            // caps.sort(function (a, b) {
-            //     const indexA = ids.indexOf(a._id);
-            //     const indexB = ids.indexOf(b._id);
-            //     return (indexA > indexB) ? 1 : -1
-            // });
-            // return caps;
-            // return null;
-        // } else return null;
+    // const caps = Traversal.getItemsOfType(["capacity"]);
+    // console.log(caps);
+    // .filter(c => ids.includes(c._id));
+    // caps.sort(function (a, b) {
+    //     const indexA = ids.indexOf(a._id);
+    //     const indexB = ids.indexOf(b._id);
+    //     return (indexA > indexB) ? 1 : -1
+    // });
+    // return caps;
+    // return null;
+    // } else return null;
     // });
 
     Handlebars.registerHelper('getPath', function (items, pathKey) {
@@ -151,6 +151,10 @@ export const registerHandlebarsHelpers = function () {
     Handlebars.registerHelper('split', function (str, separator, keep) {
         return str.split(separator)[keep];
     });
+
+    Handlebars.registerHelper('isGM', function () {
+        return game.user.isGM;
+    })
 
     // Handlebars.registerHelper('listProfiles', function () {
     //     return Traversal.getAllProfilesData()

--- a/module/system/hooks.js
+++ b/module/system/hooks.js
@@ -170,7 +170,17 @@ export default function registerHooks() {
                 html.find(".apply-dmg").each((i, btn) => {
                     btn.style.display = "none"
                   });
-            }        
-        }        
+            }
+        }
+
+        // Affiche ou non la difficulté aux PJ si l'option displayDifficulty est configurée à uniquement pour le MJ
+        if(game.settings.get("cof", "displayDifficulty") === "GM" && !game.user.isGM) {
+            html.find(".difficulty").each((i, elm) => {
+                elm.style.display = "none"
+            })
+            html.find(".difficulty-hidden").each((i, elm) => {
+                elm.style.display = "block"
+            })
+        }
     });
 }

--- a/module/system/settings.js
+++ b/module/system/settings.js
@@ -1,4 +1,4 @@
-export const registerSystemSettings = function() {
+export const registerSystemSettings = function () {
 
     game.settings.register("cof", "useRecovery", {
         name: "Points de Récupération",
@@ -45,8 +45,13 @@ export const registerSystemSettings = function() {
         hint: "Active l'affichage de la difficulté sur les jets de compétences/attributs et d'armes.",
         scope: "world",
         config: true,
-        default: true,
-        type: Boolean,
+        default: "all",
+        type: String,
+        choices: {
+            "all": "Pour tout le monde",
+            "GM": "Uniquement les jets d'attaques au MJ",
+            "none": "Désactiver"
+        },
         onChange: lang => window.location.reload()
     });
 
@@ -89,5 +94,5 @@ export const registerSystemSettings = function() {
         type: Boolean,
         onChange: lang => window.location.reload()
     });
-    
+
 };

--- a/templates/chat/skill-roll-card.hbs
+++ b/templates/chat/skill-roll-card.hbs
@@ -1,20 +1,34 @@
 {{#if showDifficulty}}
-    {{#if isSuccess}}
-        {{#if isCritical}}
-            <h2 class="success critical"><i class="fas fa-check-double"></i>&nbsp;{{localize "COF.roll.critical"}}...</h2>
-        {{else}}
-            <h2 class="success"><i class="fas fa-check"></i>&nbsp;{{localize "COF.roll.success"}}...</h2>
+    <div class="difficulty">
+        {{#if isSuccess}}
+            {{#if isCritical}}
+                <h2 class="success critical"><i class="fas fa-check-double"></i>&nbsp;{{localize "COF.roll.critical"}}...</h2>
+            {{else}}
+                <h2 class="success"><i class="fas fa-check"></i>&nbsp;{{localize "COF.roll.success"}}...</h2>
+            {{/if}}
         {{/if}}
-    {{/if}}
 
-    {{#if isFailure}}
-        {{#if isFumble}}
-            <h2 class="failure fumble"><i class="fas fa-skull-crossbones"></i>&nbsp;{{localize "COF.roll.fumble"}}...</h2>
-        {{else}}
-            <h2 class="failure"><i class="fas fa-times"></i>&nbsp;{{localize "COF.roll.failure"}}...</h2>
+        {{#if isFailure}}
+            {{#if isFumble}}
+                <h2 class="failure fumble"><i class="fas fa-skull-crossbones"></i>&nbsp;{{localize "COF.roll.fumble"}}...</h2>
+            {{else}}
+                <h2 class="failure"><i class="fas fa-times"></i>&nbsp;{{localize "COF.roll.failure"}}...</h2>
+            {{/if}}
         {{/if}}
-    {{/if}}
-    <h3><strong>{{label}}</strong> {{localize "COF.ui.difficulty"}} <strong>{{difficulty}}</strong></h3>
+        <h3><strong>{{label}}</strong> {{localize "COF.ui.difficulty"}} <strong>{{difficulty}}</strong></h3>
+    </div>
+    <div class="difficulty-hidden" style="display: none">
+        {{#if isCritical}}
+        <h2 class="standard critical"><i class="fas fa-check-double"></i>&nbsp;{{localize "COF.roll.critical"}}...</h2>
+        {{else}}
+            {{#if isFumble}}
+                <h2 class="failure fumble"><i class="fas fa-skull-crossbones"></i>&nbsp;{{localize "COF.roll.fumble"}}...</h2>
+            {{else}}
+                <h2 class="standard"><i class="fas fa-dice-d20"></i>&nbsp;{{localize "COF.roll.skillcheck"}}</h2>
+            {{/if}}
+        {{/if}}
+        <h3><strong>{{label}}</strong>
+    </div>
 {{else}}
     {{#if isCritical}}
         <h2 class="standard critical"><i class="fas fa-check-double"></i>&nbsp;{{localize "COF.roll.critical"}}...</h2>

--- a/templates/dialogs/roll-weapon-dialog.hbs
+++ b/templates/dialogs/roll-weapon-dialog.hbs
@@ -23,7 +23,8 @@
         <span class="field-label">{{localize 'COF.ui.modifier'}}</span>
     </div>
     <div class="flex1 center cell">
-        <input class="field-value readonly" id="mod" name="mod" type="text" readonly="true" value="{{numberFormat mod decimals=0 sign=true}}" data-dtype="Number"/>
+        <input class="field-value readonly" id="mod" name="mod" type="text" readonly="true"
+            value="{{numberFormat mod decimals=0 sign=true}}" data-dtype="Number" />
     </div>
 </div>
 <div class="row flexrow" style="margin-bottom: 1px;">
@@ -31,7 +32,8 @@
         <span class="field-label">{{localize 'COF.ui.critrange'}}</span>
     </div>
     <div class="flex1 center cell">
-        <input class="field-value" id="critrange" name="critrange" type="text" value="{{critrange}}" data-dtype="String"/>
+        <input class="field-value" id="critrange" name="critrange" type="text" value="{{critrange}}"
+            data-dtype="String" />
     </div>
 </div>
 <div class="row flexrow" style="margin-bottom: 1px;">
@@ -39,7 +41,8 @@
         <span class="field-label">{{localize 'COF.ui.bonus'}}</span>
     </div>
     <div class="flex1 center cell">
-        <input class="field-value" id="bonus" name="bonus" type="text" value="{{numberFormat bonus decimals=0 sign=true}}" data-dtype="Number"/>
+        <input class="field-value" id="bonus" name="bonus" type="text"
+            value="{{numberFormat bonus decimals=0 sign=true}}" data-dtype="Number" />
     </div>
 </div>
 <div class="row flexrow" style="margin-bottom: 1px;">
@@ -47,30 +50,35 @@
         <span class="field-label">{{localize 'COF.ui.malus'}}</span>
     </div>
     <div class="flex1 center cell">
-        <input class="field-value" id="malus" name="malus" type="text" value="{{numberFormat malus decimals=0 sign=true}}" data-dtype="Number"/>
+        <input class="field-value" id="malus" name="malus" type="text"
+            value="{{numberFormat malus decimals=0 sign=true}}" data-dtype="Number" />
     </div>
 </div>
-<hr/>
-{{#if (isEnabled "displayDifficulty")}}
-<!-- DIFFICULTY -->
+<hr />
+{{#if showDifficulty}}
 <div class="row flexrow" style="margin-bottom: 5px;">
     <div class="flex1 center bg-darkslate">
         <span class="field-label">{{localize 'COF.ui.difficulty'}}</span>
     </div>
     <div class="flex1 center cell">
-        <input class="field-value" id="difficulty" name="difficulty" type="text" value="{{difficulty}}" data-dtype="Number"/>
+        <input class="field-value" id="difficulty" name="difficulty" type="text" value="{{difficulty}}"
+            data-dtype="Number" />
     </div>
 </div>
-<hr/>
+{{ else if isDifficultySet}}
+    <input class="field-value" id="difficulty" name="difficulty" type="hidden" value="{{difficulty}}"
+            data-dtype="Number" />
 {{/if}}
+
 {{#if hasSkillDescr}}
-    <hr/>
-    <div>
-        <div class="flex1 center bg-darkslate">
-            <span class="field-label">Description</span>
-        </div>
-        <textarea class="readonly rollDialogDescr" readonly="true" id="skillDescr" name="skillDescr">{{skillDescr}}</textarea>
+<hr />
+<div>
+    <div class="flex1 center bg-darkslate">
+        <span class="field-label">Description</span>
     </div>
+    <textarea class="readonly rollDialogDescr" readonly="true" id="skillDescr"
+        name="skillDescr">{{skillDescr}}</textarea>
+</div>
 {{/if}}
 
 {{#if (isEnabled "useComboRolls")}}
@@ -83,11 +91,11 @@
 {{> "systems/cof/templates/dialogs/parts/roll-dmg-fields.hbs"}}
 {{/if}}
 {{#if hasDmgDescr}}
-    <hr/>
-    <div>
-        <div class="flex1 center bg-darkslate">
-            <span class="field-label">Description</span>
-        </div>
-        <textarea class="readonly rollDialogDescr" readonly="true" id="dmgDescr" name="dmgDescr">{{dmgDescr}}</textarea>
+<hr />
+<div>
+    <div class="flex1 center bg-darkslate">
+        <span class="field-label">Description</span>
     </div>
+    <textarea class="readonly rollDialogDescr" readonly="true" id="dmgDescr" name="dmgDescr">{{dmgDescr}}</textarea>
+</div>
 {{/if}}

--- a/templates/dialogs/skillroll-dialog.hbs
+++ b/templates/dialogs/skillroll-dialog.hbs
@@ -23,7 +23,8 @@
         <span class="field-label">{{localize 'COF.ui.modifier'}}</span>
     </div>
     <div class="flex1 center cell">
-        <input class="field-value readonly" id="mod" name="mod" type="text" readonly="true" value="{{numberFormat mod decimals=0 sign=true}}" data-dtype="Number"/>
+        <input class="field-value readonly" id="mod" name="mod" type="text" readonly="true"
+            value="{{numberFormat mod decimals=0 sign=true}}" data-dtype="Number" />
     </div>
 </div>
 <div class="row flexrow" style="margin-bottom: 1px;">
@@ -31,7 +32,8 @@
         <span class="field-label">{{localize 'COF.ui.critrange'}}</span>
     </div>
     <div class="flex1 center cell">
-        <input class="field-value" id="critrange" name="critrange" type="text" value="{{critrange}}" data-dtype="String"/>
+        <input class="field-value" id="critrange" name="critrange" type="text" value="{{critrange}}"
+            data-dtype="String" />
     </div>
 </div>
 <div class="row flexrow" style="margin-bottom: 1px;">
@@ -39,7 +41,8 @@
         <span class="field-label">{{localize 'COF.ui.bonus'}}</span>
     </div>
     <div class="flex1 center cell">
-        <input class="field-value" id="bonus" name="bonus" type="text" value="{{numberFormat bonus decimals=0 sign=true}}" data-dtype="Number"/>
+        <input class="field-value" id="bonus" name="bonus" type="text"
+            value="{{numberFormat bonus decimals=0 sign=true}}" data-dtype="Number" />
     </div>
 </div>
 <div class="row flexrow" style="margin-bottom: 1px;">
@@ -47,26 +50,28 @@
         <span class="field-label">{{localize 'COF.ui.malus'}}</span>
     </div>
     <div class="flex1 center cell">
-        <input class="field-value" id="malus" name="malus" type="text" value="{{numberFormat malus decimals=0 sign=true}}" data-dtype="Number"/>
+        <input class="field-value" id="malus" name="malus" type="text"
+            value="{{numberFormat malus decimals=0 sign=true}}" data-dtype="Number" />
     </div>
 </div>
-{{#if (isEnabled "displayDifficulty")}}
-    <hr/>
-    <div class="row flexrow" style="margin-bottom: 5px;">
-        <div class="flex1 center bg-darkslate">
-            <span class="field-label">{{localize 'COF.ui.difficulty'}}</span>
-        </div>
-        <div class="flex1 center cell">
-            <input class="field-value" id="difficulty" name="difficulty" type="text" value="" data-dtype="Number"/>
-        </div>
+{{#if (or (isEnabled "displayDifficulty" "all") (isEnabled "displayDifficulty" "GM"))}}
+<hr />
+<div class="row flexrow" style="margin-bottom: 5px;">
+    <div class="flex1 center bg-darkslate">
+        <span class="field-label">{{localize 'COF.ui.difficulty'}}</span>
     </div>
+    <div class="flex1 center cell">
+        <input class="field-value" id="difficulty" name="difficulty" type="text" value="" data-dtype="Number" />
+    </div>
+</div>
 {{/if}}
 {{#if hasDescription}}
-    <hr/>
-    <div>
-        <div class="flex1 center bg-darkslate">
-            <span class="field-label">Description</span>
-        </div>
-        <textarea class="readonly rollDialogDescr" readonly="true" id="skillDescr" name="skillDescr">{{skillDescr}}</textarea>
+<hr />
+<div>
+    <div class="flex1 center bg-darkslate">
+        <span class="field-label">Description</span>
     </div>
+    <textarea class="readonly rollDialogDescr" readonly="true" id="skillDescr"
+        name="skillDescr">{{skillDescr}}</textarea>
+</div>
 {{/if}}


### PR DESCRIPTION
* Modification de l'option pour la configuration de l'affichage de la difficulté
* Masquage du champ de difficulté aux PJ dans la modal roll-weapon si l'option est activée pour le GM
* Masquage des résultats uniquement pour les joueurs si l'option est activée pour le GM