### PR TITLE
Equipable effects

### DIFF
--- a/module/actors/actor-sheet.js
+++ b/module/actors/actor-sheet.js
@@ -463,7 +463,7 @@ export class CofActorSheet extends CofBaseSheet {
             data.combat.categories.push({
                 id: category,
                 label: game.cof.config.itemCategories[category],
-                items: Object.values(data.items).filter(item => item.type === "item" && item.data.subtype === category && item.data.worn).sort((a, b) => (a.name > b.name) ? 1 : -1)
+                items: Object.values(data.items).filter(item => item.type === "item" && item.data.subtype === category && item.data.worn && (item.data.properties.weapon || item.data.properties.protection)).sort((a, b) => (a.name > b.name) ? 1 : -1)
             });
             data.inventory.categories.push({
                 id: category,

--- a/module/actors/actor.js
+++ b/module/actors/actor.js
@@ -829,5 +829,21 @@ export class CofActor extends Actor {
         return Macros.rollStatMacro(this, stat, bonus, malus);
     }
 
+    /**
+    * @name syncItemActiveEffects
+    * @param {*} item 
+    * @description synchronise l'état des effets qui appartiennent à un item équipable avec l'état "équipé" de cet item
+    * @returns {Promise}
+    */
+    syncItemActiveEffects(item){
+        // Récupération des effets qui proviennent de l'item
+        let effectsData = this.effects.filter(effect=>effect.data.origin.endsWith(item.id))?.map(effect=> duplicate(effect.data));
+        if (effectsData.length > 0){        
+            effectsData.forEach(effect=>effect.disabled = !item.data.data.worn);
+
+            this.updateEmbeddedDocuments("ActiveEffect", effectsData);
+        }
+    }    
+
 }
 

--- a/module/controllers/inventory.js
+++ b/module/controllers/inventory.js
@@ -50,7 +50,7 @@ export class Inventory {
                     }    
                 }
             }
-            return item.update(itemData);
+            return item.update(itemData).then(item=>actor.syncItemActiveEffects(item));
         }
     }
 

--- a/module/controllers/inventory.js
+++ b/module/controllers/inventory.js
@@ -50,7 +50,9 @@ export class Inventory {
                     }    
                 }
             }
-            return item.update(itemData).then(item=>actor.syncItemActiveEffects(item));
+            return item.update(itemData).then((item)=>{
+                if (!event.shiftKey) actor.syncItemActiveEffects(item);
+            });
         }
     }
 

--- a/module/system/hooks.js
+++ b/module/system/hooks.js
@@ -193,14 +193,16 @@ export default function registerHooks() {
     /**
      * Intercepte la création d'un active effect
      * Si l'effet provient d'un item équipable, on disable l'effet si l'item n'est pas équipé (par défaut il n'est pas équipé)
+     * Il n'y as pas de preCreateActiveEffect pour les effets transférés depuis un item
+     * On procède donc à une mise à jour de l'effet
      */
     Hooks.on("createActiveEffect", (activeEffect)=>{
         // Si l'effet ne s'applique pas à un actor, on quitte en laissant l'effet se créer normalement
-        if (!activeEffect.parent instanceof CofActor) return true;
+        if (!activeEffect.parent instanceof CofActor) return;
 
         let origin = activeEffect.data.origin;
         // Si l'effet ne provient pas d'un item, on quitte en laissant l'effet se créer normalement
-        if (!/Item\.[^.]+$/.test(origin)) return true;
+        if (!/Item\.[^.]+$/.test(origin)) return;
 
         let parts = origin.split('.');
         let item;
@@ -216,9 +218,12 @@ export default function registerHooks() {
 
         // Si l'item parent n'est pas équipable, on quitte en laissant l'effet se créer normalement
         let itemData = item.data;
-        if (!itemData.data.properties.equipable) return true;
+        if (!itemData.data.properties.equipable) return;
         
+        // Si l'effet est déjà à jour, on quitte
+        if (activeEffect.data.disabled === !itemData.worn) return;
+
         // On met à jour l'effet en fonction du fait que l'item est équipé ou non
-        activeEffect.data.disabled = !itemData.worn;
+        activeEffect.update({disabled: !itemData.worn});
     });
 }

--- a/module/system/hooks.js
+++ b/module/system/hooks.js
@@ -1,3 +1,4 @@
+import { CofActor } from "../actors/actor.js";
 import {Hitpoints} from "../controllers/hitpoints.js";
 import {CharacterGeneration} from "../system/chargen.js";
 
@@ -187,5 +188,37 @@ export default function registerHooks() {
                   });
             }        
         }        
+    });
+
+    /**
+     * Intercepte la création d'un active effect
+     * Si l'effet provient d'un item équipable, on disable l'effet si l'item n'est pas équipé (par défaut il n'est pas équipé)
+     */
+    Hooks.on("createActiveEffect", (activeEffect)=>{
+        // Si l'effet ne s'applique pas à un actor, on quitte en laissant l'effet se créer normalement
+        if (!activeEffect.parent instanceof CofActor) return true;
+
+        let origin = activeEffect.data.origin;
+        // Si l'effet ne provient pas d'un item, on quitte en laissant l'effet se créer normalement
+        if (!/Item\.[^.]+$/.test(origin)) return true;
+
+        let parts = origin.split('.');
+        let item;
+
+        // Récupération de l'item parent en fonction de si il vient d'un actor du compendium ou d'un token
+        if (parts[0] === "Actor"){
+            item = ActorDirectory.collection.get(parts[1])?.getEmbeddedDocument("Item",parts[3]);
+        }
+        else if (parts[0] === "Scene"){
+            item = SceneDirectory.collection.get(parts[1])?.tokens.get(parts[3])?.getEmbeddedDocument("Item",parts[5]);
+        }
+        else return true;
+
+        // Si l'item parent n'est pas équipable, on quitte en laissant l'effet se créer normalement
+        let itemData = item.data;
+        if (!itemData.data.properties.equipable) return true;
+        
+        // On met à jour l'effet en fonction du fait que l'item est équipé ou non
+        activeEffect.data.disabled = !itemData.worn;
     });
 }


### PR DESCRIPTION
- Ajout d'un filtre pour n'afficher que les items de type "arme" ou "protection" sur l'onglet combat
- Pour les Items "équipable", Activation/Désactivation des active effects provenant de l'item lors que l'on équipe/déséquipe cet item
- Possibilité d'ignorer la synchro item/effet en maintenant la touche MAJ lors du clique sur le bouton