### PR TITLE
Corrections avant release

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -355,7 +355,8 @@
   "COF.notification.MacroUnknownStat" : "The skill to test is unknown",
   "COF.notification.MacroNotAnEncounter" : "The selected token is not an encounter",
   "COF.notification.WeaponIndexMissing" : "This encounter does not posses a weapon number",
-  "COF.notification.NotEnoughFreeHands" : "Not enough free hands to equip this object",  
+  "COF.notification.NotEnoughFreeHands" : "Not enough free hands to equip this object",
+  "COF.notification.ArmorSlotNotAvailable" : "This armor slot is not available",    
 
   "COF.dialog.deletePath.title": "Delete the path ?",
   "COF.dialog.deleteProfile.title": "Delete the profile ?",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -356,7 +356,8 @@
   "COF.notification.MacroUnknownStat" : "La compétence à tester n'a pas été reconnue",
   "COF.notification.MacroNotAnEncounter" : "Le token sélectionné n'est pas une rencontre",
   "COF.notification.WeaponIndexMissing" : "Cette rencontre ne possède pas d'arme numéro",
-  "COF.notification.NotEnoughFreeHands" : "Pas suffisament de mains libres pour équiper l'objet",  
+  "COF.notification.NotEnoughFreeHands" : "Pas suffisament de mains libres pour équiper l'objet",
+  "COF.notification.ArmorSlotNotAvailable" : "L'emplacement pour équiper cette armure n'est pas disponible",
 
   "COF.dialog.deletePath.title": "Supprimer la voie ?",
   "COF.dialog.deleteProfile.title": "Supprimer le profil ?",

--- a/module/actors/actor-sheet.js
+++ b/module/actors/actor-sheet.js
@@ -229,12 +229,12 @@ export class CofActorSheet extends CofBaseSheet {
     _hasEnoughFreeHands(event){
         // Si le contrôle de mains libres n'est pas demandé, on renvoi Vrai
         let checkFreehands = game.settings.get("cof", "checkFreeHandsBeforeEquip");
-        if (!checkFreehands || +checkFreehands === 0) return true;
+        if (!checkFreehands || checkFreehands === "none") return true;
 
         // Si le contrôle est ignoré ponctuellement avec la touche MAJ, on renvoi Vrai
         // checkFreeHands === 1 => Tous le monde peux ignorer le contrôle
         // checkFreeHands === 2 => Uniquement le MJ peux ignorer le contrôle
-        if (event.shiftKey && (+checkFreehands === 1 || (+checkFreehands === 2 && game.user.isGM))) return true;
+        if (event.shiftKey && (checkFreehands === "all" || (checkFreehands === "gm" && game.user.isGM))) return true;
 
         // Récupération de l'item
         const li = $(event.currentTarget).closest(".item");

--- a/module/actors/actor-sheet.js
+++ b/module/actors/actor-sheet.js
@@ -198,13 +198,27 @@ export class CofActorSheet extends CofBaseSheet {
 
     _onToggleEquip(event) {
         event.preventDefault();
-        if (this._hasEnoughFreeHands(event)){
+        if (this._canEquipItem(event)){
             AudioHelper.play({ src: "/systems/cof/sounds/sword.mp3", volume: 0.8, autoplay: true, loop: false }, false);
             return Inventory.onToggleEquip(this.actor, event);
         }
-        else{
+    }
+
+    /**
+     * Check if an item can be equiped
+     * @param event
+     * @private
+     */        
+    _canEquipItem(event){
+        if (!this._hasEnoughFreeHands(event)){
             ui.notifications.warn(game.i18n.localize("COF.notification.NotEnoughFreeHands"));
+            return false;
         }
+        if (!this._isArmorSlotAvailable(event)){
+            ui.notifications.warn(game.i18n.localize("COF.notification.ArmorSlotNotAvailable"));
+            return false;
+        }
+        return true;
     }
 
     /**
@@ -241,6 +255,41 @@ export class CofActorSheet extends CofBaseSheet {
         itemsInHands.forEach(item=>usedHands += item.data.data.properties["2h"] ? 2 : 1);                
 
         return usedHands + neededHands <= 2;        
+    }
+
+    /**
+     * Check if armor slot is available to equip this item
+     * @param event
+     * @private
+     */        
+    _isArmorSlotAvailable(event){
+        // Si le contrôle de disponibilité de l'emplacement d'armure n'est pas demandé, on renvoi Vrai
+        let checkArmorSlotAvailability = game.settings.get("cof", "checkArmorSlotAvailability");
+        if (!checkArmorSlotAvailability || checkArmorSlotAvailability === "none") return true;
+
+        // Si le contrôle est ignoré ponctuellement avec la touche MAJ, on renvoi Vrai
+        if (event.shiftKey && (checkArmorSlotAvailability === "all" || (checkArmorSlotAvailability === "gm" && game.user.isGM))) return true;
+        
+        // Récupération de l'item
+        const li = $(event.currentTarget).closest(".item");
+        const item = this.actor.items.get(li.data("itemId"));
+        const itemData = item.data.data;
+
+        // Si l'objet est équipé, on tente de le déséquiper donc on ne fait pas de contrôle et on renvoi Vrai
+        if (itemData.worn) return true;
+        
+        // Si l'objet n'est pas une protection, on renvoi Vrai
+        if (!itemData.properties.protection) return true;
+
+        // Recheche d'une item de type protection déjà équipé dans le slot cible
+        let equipedItem = this.actor.items.find((slotItem)=>{
+            let slotItemData = slotItem.data.data;
+
+            return slotItemData.properties?.protection && slotItemData.properties.equipable && slotItemData.worn && slotItemData.slot === itemData.slot;
+        });
+        
+        // Renvoi vrai si le le slot est libre, sinon renvoi faux
+        return !equipedItem;    
     }
 
     /**
@@ -417,6 +466,10 @@ export class CofActorSheet extends CofBaseSheet {
                 const actor = this.actor;
                 let sameActor = (data.actorId === actor.id) && ((!actor.isToken && !data.tokenId) || (data.tokenId === actor.token.id));
                 if (sameActor) return this._onSortItem(event, itemData);
+
+                // On force le nouvel Item a ne pas être équipé (notamment lors du transfert d'un inventaire à un autre)
+                if (itemData.data.worn) itemData.data.worn = false;
+
                 // Create the owned item
                 return this.actor.createEmbeddedDocuments("Item", [itemData]).then((item)=>{                    
                     // Si il n'y as pas d'actor id, il s'agit d'un objet du compendium, on quitte

--- a/module/system/settings.js
+++ b/module/system/settings.js
@@ -129,19 +129,19 @@ export const registerSystemSettings = function() {
         hint: "Vérifier que le personnage a assez de mains libres pour équiper un objet (Maintenir MAJ pour ignorer le contrôle)",
         scope: "world",
         config: true,
-        default: "0",
+        default: "none",
         type: String,
         choices: {
-            "0" : "Ne pas vérifier",
-            "1" : "Vérification (ignorable par tous)",
-            "2" : "Vérification (ignorable uniquement par le MJ)"
+            "none" : "Ne pas vérifier",
+            "all" : "Vérification (ignorable par tous)",
+            "gm" : "Vérification (ignorable uniquement par le MJ)"
         },        
         onChange: lang => window.location.reload()
     });
     
     game.settings.register("cof", "checkArmorSlotAvailability", {
         name: "Vérification des emplacements d'armure",
-        hint: "Vérifier que l'emplacement d'armure est disponible avant d'équiper un objet (Maintenir MAJ pour ignorer le contrôle)",
+        hint: "Vérifier la disponibilité d'un emplacement avant d'équiper une armure (Maintenir MAJ pour ignorer le contrôle)",
         scope: "world",
         config: true,
         default: "none",

--- a/module/system/settings.js
+++ b/module/system/settings.js
@@ -137,5 +137,20 @@ export const registerSystemSettings = function() {
             "2" : "Vérification (ignorable uniquement par le MJ)"
         },        
         onChange: lang => window.location.reload()
+    });
+    
+    game.settings.register("cof", "checkArmorSlotAvailability", {
+        name: "Vérification des emplacements d'armure",
+        hint: "Vérifier que l'emplacement d'armure est disponible avant d'équiper un objet (Maintenir MAJ pour ignorer le contrôle)",
+        scope: "world",
+        config: true,
+        default: "none",
+        type: String,
+        choices: {
+            "none" : "Ne pas vérifier",
+            "all" : "Vérification (ignorable par tous)",
+            "gm" : "Vérification (ignorable uniquement par le MJ)"
+        },        
+        onChange: lang => window.location.reload()
     });    
 };


### PR DESCRIPTION
- Lors de la création d'un item sur un actor, forçage de l'item à l'état "non equipé"
- Ajout d'un contrôle pour empêcher d'équiper 2 protections dans le même slot
- Ajout d'une configuration pour désactiver le contrôle ou permettre d'ignorer le contrôle en maintenant SHIFT pour le tous le monde ou uniquement le MJ